### PR TITLE
Add db-journal file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .vscode/
 .sqbpro
+*.db-journal


### PR DESCRIPTION
When working with farmers-marked database, a journal file gets created and it may be committed by accident. This PR adds SQLite journal files to gitignore to prevent that. 

More info about the journal files - https://stackoverflow.com/a/26209121